### PR TITLE
chore: upgrade to python3.10 and improve template standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/osx,linux,python,windows,pycharm,visualstudiocode
 lambda_env.json
 packaged.yaml
+samconfig.toml

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ LLM 参数均为可选，默认值如上图所示。自定义 System Prompt 请�
 2024-12-11:
 使用 Converse API 调用 Bedrock 模型。默认使用模型调整为 Amazon Nova Lite。
 
+2025-12-08:
+1. Lambda 运行时升级至 python3.10，Layer 新增支持 python3.10 和 python3.11。
+2. 优化事件处理逻辑，移除部分事件的 InputTransformer，由 Lambda 统一处理格式化。
+3. 改进 CloudFormation 模板代码规范性。
+
 ## 附录
 
 [AWS博客：基于AWS Serverless 一键启用微信/钉钉告警通知

--- a/README_en.md
+++ b/README_en.md
@@ -88,6 +88,11 @@ Added the ability to connect to the Bedrock-managed LLM for information sorting.
 2024-12-11:
 Use the Converse API to call Bedrock models. The default usage model is tuned to Amazon Nova Lite.
 
+2025-12-08:
+1. Lambda runtime upgraded to python3.10, Layer added support for python3.10 and python3.11.
+2. Optimized event processing logic, removed InputTransformer for some events, unified formatting handled by Lambda.
+3. Improved CloudFormation template code standards.
+
 ## Appendix
 
 [AWS Blog: Enable WeChat/DingTalk Alarm Notification with One-Click Based on AWS Serverless](https://aws.amazon.com/cn/blogs/china/enable-wechat-dingtalk-alarm-notification-with-one-click-based-on-aws-serverless/)

--- a/template.yaml
+++ b/template.yaml
@@ -8,70 +8,83 @@ Metadata:
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README_sar.md
-    Labels: [ 'Feishu', 'Eventbridge' ]
+    Labels:
+      - Feishu
+      - Eventbridge
     HomePageUrl: https://github.com/Chris-wa-He/AWS-Lambda-notifier
-    SemanticVersion: 1.6.1
+    SemanticVersion: 1.6.3
     SourceCodeUrl: https://github.com/Chris-wa-He/AWS-Lambda-notifier
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "Notifier Parameters"
+          default: Notifier Parameters
         Parameters:
           - WebhookURL
           - EnableDebug
       - Label:
-          default: "Large Language Model Parameters"
+          default: Large Language Model Parameters
         Parameters:
           - EnableLLM
           - LlmRegion
           - LlmModelId
-          - AnthropicVersion
           - LlmMaxTokens
           - SystemPrompt
     ParameterLabels:
       WebhookURL:
-        default: "WebhookURL (Required)"
+        default: WebhookURL (Required)
       EnableDebug:
-        default: "Enable Debug (Optional)"
+        default: Enable Debug (Optional)
       EnableLLM:
-        default: "EnableLLM (Required)"
+        default: EnableLLM (Required)
       LlmRegion:
-        default: "LLM Region (Optional)"
+        default: LLM Region (Optional)
       LlmModelId:
-        default: "LLM Model Id (Optional)"
+        default: LLM Model Id (Optional)
       LlmMaxTokens:
-        default: "LLM Max Tokens (Optional)"
+        default: LLM Max Tokens (Optional)
       SystemPrompt:
-        default: "System Prompt (Optional)"
+        default: System Prompt (Optional)
 
 Parameters:
   WebhookURL:
     Type: String
-    Description: "Feishu Chat bot URL includes security token.\n Sample: https://open.feishu.cn/open-apis/bot/v2/hook/XXXXXXXX"
+    Description: |-
+      Feishu Chat bot URL includes security token.
+       Sample: https://open.feishu.cn/open-apis/bot/v2/hook/XXXXXXXX
   EnableDebug:
     Type: String
-    Default: "false"
-    Description: "Enable debug mode.\n Sample: true"
+    Default: 'false'
+    Description: |-
+      Enable debug mode.
+       Sample: true
   EnableLLM:
     Type: String
-    Default: "false"
-    Description: "Enable LLM to generate response message.\n Sample: true"
+    Default: 'false'
+    Description: |-
+      Enable LLM to generate response message.
+       Sample: true
   LlmRegion:
     Type: String
-    Default: "us-east-1"
-    Description: "LLM region. \n Sample: us-east-1"
+    Default: us-east-1
+    Description: |-
+      LLM region.
+       Sample: us-east-1
   LlmModelId:
     Type: String
-    Default: "amazon.nova-lite-v1:0"
-    Description: "LLM model id. The model id needs to be in the support list of the Bedrock Converse API.\n Sample: anthropic.claude-3-sonnet-20240229-v1:0"
+    Default: amazon.nova-lite-v1:0
+    Description: |-
+      LLM model id. The model id needs to be in the support list of the Bedrock Converse API.
+       Sample: anthropic.claude-3-sonnet-20240229-v1:0
   LlmMaxTokens:
     Type: Number
     Default: 2048
-    Description: "LLM max tokens. \n Sample: 1024"
+    Description: |-
+      LLM max tokens.
+       Sample: 1024
   SystemPrompt:
     Type: String
-    Default: ""
-    Description: "For customize System prompt."
+    Default: ''
+    Description: For customize System prompt.
 
 Resources:
   FeishuNotifierLambdaLayer:
@@ -85,6 +98,8 @@ Resources:
         - python3.7
         - python3.8
         - python3.9
+        - python3.10
+        - python3.11
 
   FeishuNotifierLambda:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -96,21 +111,14 @@ Resources:
         - !Ref FeishuNotifierLambdaLayer
       Environment:
         Variables:
-          SECRET_ARN:
-            Ref: WebhookSecret
-          ENABLE_DEBUG:
-            Ref: EnableDebug
-          EnableLLM:
-            Ref: EnableLLM
-          LLM_REGION:
-            Ref: LlmRegion
-          LLM_MODEL_ID:
-            Ref: LlmModelId
-          LLM_Max_Tokens:
-            Ref: LlmMaxTokens
-          System_Prompt:
-            Ref: SystemPrompt
-      Runtime: python3.9
+          SECRET_ARN: !Ref WebhookSecret
+          ENABLE_DEBUG: !Ref EnableDebug
+          EnableLLM: !Ref EnableLLM
+          LLM_REGION: !Ref LlmRegion
+          LLM_MODEL_ID: !Ref LlmModelId
+          LLM_Max_Tokens: !Ref LlmMaxTokens
+          System_Prompt: !Ref SystemPrompt
+      Runtime: python3.10
       Policies:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Ref WebhookSecret
@@ -120,7 +128,7 @@ Resources:
               Action:
                 - bedrock:InvokeModel
                 - bedrock:InvokeModelWithResponseStream
-              Resource: 'arn:aws:bedrock:*::foundation-model/*'
+              Resource: arn:aws:bedrock:*::foundation-model/*
       Events:
         SNSEvent:
           Type: SNS
@@ -140,24 +148,24 @@ Resources:
           - Sid: Default_Statement
             Effect: Allow
             Principal:
-              AWS: "*"
+              AWS: '*'
             Action:
               - sns:Publish
             Resource: !Ref ServerlessNotifierSNSTopic
             Condition:
               StringEquals:
-                "AWS:SourceOwner": !Ref "AWS::AccountId"
+                AWS:SourceOwner: !Ref AWS::AccountId
           - Sid: Eventbridge_Statement
             Effect: Allow
             Principal:
-              Service: "events.amazonaws.com"
+              Service: events.amazonaws.com
             Action:
               - sns:Publish
             Resource: !Ref ServerlessNotifierSNSTopic
           - Sid: Costalerts_Statement
             Effect: Allow
             Principal:
-              Service: "costalerts.amazonaws.com"
+              Service: costalerts.amazonaws.com
             Action:
               - sns:Publish
             Resource: !Ref ServerlessNotifierSNSTopic
@@ -168,8 +176,7 @@ Resources:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'WebhookSecret: Store Chat bot URL'
-      SecretString:
-        Ref: WebhookURL
+      SecretString: !Ref WebhookURL
 
   EventRuleEC2StateChange:
     Type: AWS::Events::Rule
@@ -190,12 +197,12 @@ Resources:
           Id: Send2SNS
           InputTransformer:
             InputPathsMap:
-              instance-id: "$.detail.instance-id"
-              region: "$.region"
-              state: "$.detail.state"
-              time: "$.time"
-            InputTemplate:
-              "\"EC2状态变化告警: \\n时间: <time> \\n区域: <region> \\n实例id: <instance-id> \\n状态: <state>\""
+              instance-id: $.detail.instance-id
+              region: $.region
+              state: $.detail.state
+              time: $.time
+            InputTemplate: '"EC2状态变化告警: \n时间: <time> \n区域: <region> \n实例id: <instance-id>
+              \n状态: <state>"'
 
   EventRuleAwsHealth:
     Type: AWS::Events::Rule
@@ -209,15 +216,15 @@ Resources:
       Targets:
         - Arn: !Ref ServerlessNotifierSNSTopic
           Id: Send2SNS
-          InputTransformer:
-            InputPathsMap:
-              resource: "$.resources[0]"
-              region: "$.region"
-              time: "$.time"
-              type: "$.detail.eventTypeCode"
-              desc: "$.detail.eventDescription[0].latestDescription"
-            InputTemplate:
-              "\"AWS健康事件: \\n时间: <time> \\n区域: <region> \\n受影响资源: <resource> \\n类型: <type> \\n描述: <desc>\""
+          # InputTransformer:
+          #   InputPathsMap:
+          #     resource: "$.resources[0]"
+          #     region: "$.region"
+          #     time: "$.time"
+          #     type: "$.detail.eventTypeCode"
+          #     desc: "$.detail.eventDescription[0].latestDescription"
+          #   InputTemplate:
+          #     "\"AWS健康事件: \\n时间: <time> \\n区域: <region> \\n受影响资源: <resource> \\n类型: <type> \\n描述: <desc>\""
 
   EventRuleAwsHealthAbuse:
     Type: AWS::Events::Rule
@@ -231,16 +238,16 @@ Resources:
       Targets:
         - Arn: !Ref ServerlessNotifierSNSTopic
           Id: Send2SNS
-          InputTransformer:
-            InputPathsMap:
-              resource: "$.resources"
-              region: "$.region"
-              time: "$.time"
-              startTime: "$.detail.startTime"
-              type: "$.detail.eventTypeCode"
-              desc: "$.detail.eventDescription[0].latestDescription"
-            InputTemplate:
-              "\"AWS异常使用事件: \\n通知生成时间: <time> \\n事件开始时间: <startTime> \\n区域: <region> \\n受影响资源: <resource> \\n类型: <type> \\n描述: <desc>\""
+          # InputTransformer:
+          #   InputPathsMap:
+          #     resource: "$.resources"
+          #     region: "$.region"
+          #     time: "$.time"
+          #     startTime: "$.detail.startTime"
+          #     type: "$.detail.eventTypeCode"
+          #     desc: "$.detail.eventDescription[0].latestDescription"
+          #   InputTemplate:
+          #     "\"AWS异常使用事件: \\n通知生成时间: <time> \\n事件开始时间: <startTime> \\n区域: <region> \\n受影响资源: <resource> \\n类型: <type> \\n描述: <desc>\""
 
   EventRuleCloudWatchAlarmStateChange:
     Type: AWS::Events::Rule
@@ -254,21 +261,21 @@ Resources:
       Targets:
         - Id: Send2SNS
           Arn: !Ref ServerlessNotifierSNSTopic
-          InputTransformer:
-            InputPathsMap:
-              alarmName: $.detail.alarmName
-              description: $.detail.configuration.description
-              reason: $.detail.state.reason
-              region: $.region
-              resources: $.resources
-              time: $.time
-            InputTemplate:
-              "\"Cloud Watch 状态变化告警: \\n时间: <time> \\n区域: <region> \\n资源: <resources> \\n告警名称: <alarmName> \\n描述: <description> \\n原因: <reason>\""
+          # InputTransformer:
+          #   InputPathsMap:
+          #     alarmName: $.detail.alarmName
+          #     description: $.detail.configuration.description
+          #     reason: $.detail.state.reason
+          #     region: $.region
+          #     resources: $.resources
+          #     time: $.time
+          #   InputTemplate:
+          #     "\"Cloud Watch 状态变化告警: \\n时间: <time> \\n区域: <region> \\n资源: <resources> \\n告警名称: <alarmName> \\n描述: <description> \\n原因: <reason>\""
 
 Outputs:
   EventBusName:
     Description: Event Bus name for integration.
-    Value: 'default'
+    Value: default
   SnsTopicArn:
     Description: SNS topic ARN for integration.
     Value: !Ref ServerlessNotifierSNSTopic


### PR DESCRIPTION
- Lambda runtime: python3.9 → python3.10
- Layer: add python3.10/3.11 support
- Simplify event processing by removing InputTransformer
- Improve CloudFormation template formatting
- Add samconfig.toml to .gitignore